### PR TITLE
Don't break into the debugger on errors

### DIFF
--- a/camera.py
+++ b/camera.py
@@ -159,12 +159,8 @@ class ProjectPoints3D(ProjectPoints):
         
     @property
     def z_coords(self):
-        
-        try:
-            assert(self.v.r.shape[1]==3)
-            return RigidTransform(v=self.v, rt=self.rt, t=self.t)[:,2]
-        except:
-            import pdb; pdb.set_trace()
+        assert(self.v.r.shape[1]==3)
+        return RigidTransform(v=self.v, rt=self.rt, t=self.t)[:,2]
     
     def compute_dr_wrt(self, wrt):
         result = ProjectPoints.compute_dr_wrt(self, wrt)
@@ -182,19 +178,15 @@ class ProjectPoints3D(ProjectPoints):
             
             result = sp.csc_matrix((data, (IS, JS)), shape=(self.v.r.size, wrt.r.size))
         else:
-            try:
-                bigger = np.zeros((result.shape[0]/2, 3, result.shape[1]))
-                bigger[:, :2, :] = result.reshape((-1, 2, result.shape[-1]))
-                drz = self.z_coords.dr_wrt(wrt)
-                if drz is not None:
-                    if sp.issparse(drz):
-                        drz = drz.todense()
-                    bigger[:,2,:] = drz.reshape(bigger[:,2,:].shape)
+            bigger = np.zeros((result.shape[0]/2, 3, result.shape[1]))
+            bigger[:, :2, :] = result.reshape((-1, 2, result.shape[-1]))
+            drz = self.z_coords.dr_wrt(wrt)
+            if drz is not None:
+                if sp.issparse(drz):
+                    drz = drz.todense()
+                bigger[:,2,:] = drz.reshape(bigger[:,2,:].shape)
 
-                result = bigger.reshape((-1, bigger.shape[-1]))
-            except:
-                import pdb; pdb.set_trace()
-                    
+            result = bigger.reshape((-1, bigger.shape[-1]))
 
         return result            
             

--- a/renderer.py
+++ b/renderer.py
@@ -359,32 +359,25 @@ class ColoredRenderer(BaseRenderer):
 
     @depends_on('f', 'camera', 'vc')
     def boundarycolor_image(self):
-
-        try:
-            return self.draw_boundarycolor_image(with_vertex_colors=True)
-        except:
-            import pdb; pdb.set_trace()
+        return self.draw_boundarycolor_image(with_vertex_colors=True)
 
 
     def draw_color_image(self, gl):
         self._call_on_changed()
-        try:
-            gl.Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        gl.Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-            # use face colors if given
-            # FIXME: this won't work for 2 channels
-            draw_colored_verts(gl, self.v.r, self.f, self.vc.r)
+        # use face colors if given
+        # FIXME: this won't work for 2 channels
+        draw_colored_verts(gl, self.v.r, self.f, self.vc.r)
 
-            result = np.asarray(deepcopy(gl.getImage()[:,:,:self.num_channels].squeeze()), np.float64)
+        result = np.asarray(deepcopy(gl.getImage()[:,:,:self.num_channels].squeeze()), np.float64)
 
-            if hasattr(self, 'background_image'):
-                bg_px = np.tile(np.atleast_3d(self.visibility_image) == 4294967295, (1,1,self.num_channels)).squeeze()
-                fg_px = 1 - bg_px
-                result = bg_px * self.background_image + fg_px * result
+        if hasattr(self, 'background_image'):
+            bg_px = np.tile(np.atleast_3d(self.visibility_image) == 4294967295, (1,1,self.num_channels)).squeeze()
+            fg_px = 1 - bg_px
+            result = bg_px * self.background_image + fg_px * result
 
-            return result
-        except:
-            import pdb; pdb.set_trace()
+        return result
 
     @depends_on(dterms+terms)
     def color_image(self):
@@ -412,14 +405,11 @@ class ColoredRenderer(BaseRenderer):
     @depends_on(terms+dterms)    
     def boundarycolor_image(self): 
         self._call_on_changed()
-        try:
-            gl = self.glf
-            colors = self.vc.r.reshape((-1,3))[self.vpe.ravel()]
-            gl.Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-            draw_colored_primitives(gl, self.v.r.reshape((-1,3)), self.vpe, colors)
-            return np.asarray(deepcopy(gl.getImage()), np.float64)
-        except:
-            import pdb; pdb.set_trace()
+        gl = self.glf
+        colors = self.vc.r.reshape((-1,3))[self.vpe.ravel()]
+        gl.Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        draw_colored_primitives(gl, self.v.r.reshape((-1,3)), self.vpe, colors)
+        return np.asarray(deepcopy(gl.getImage()), np.float64)
             
 
         
@@ -538,17 +528,14 @@ class TexturedRenderer(ColoredRenderer):
     @depends_on(terms+dterms)    
     def boundarycolor_image(self): 
         self._call_on_changed()
-        try:
-            gl = self.glf
-            colors = self.vc.r.reshape((-1,3))[self.vpe.ravel()]
-            gl.Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-            self.texture_mapping_on(gl, with_vertex_colors=False if colors is None else True)
-            gl.TexCoordPointerf(2,0, self.wireframe_tex_coords.ravel())
-            draw_colored_primitives(self.glf, self.v.r.reshape((-1,3)), self.vpe, colors)
-            self.texture_mapping_off(gl)
-            return np.asarray(deepcopy(gl.getImage()), np.float64)
-        except:
-            import pdb; pdb.set_trace()
+        gl = self.glf
+        colors = self.vc.r.reshape((-1,3))[self.vpe.ravel()]
+        gl.Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        self.texture_mapping_on(gl, with_vertex_colors=False if colors is None else True)
+        gl.TexCoordPointerf(2,0, self.wireframe_tex_coords.ravel())
+        draw_colored_primitives(self.glf, self.v.r.reshape((-1,3)), self.vpe, colors)
+        self.texture_mapping_off(gl)
+        return np.asarray(deepcopy(gl.getImage()), np.float64)
 
     def draw_color_image(self, with_vertex_colors=True, with_texture_on=True):
         self._call_on_changed()

--- a/test_renderer.py
+++ b/test_renderer.py
@@ -426,10 +426,7 @@ class TestRenderer(unittest.TestCase):
             # print '-------------------------------------------'
             #lighting.set(vc=mesh_colors, v=mesh_verts)
 
-            try:
-                lighting.vc = mesh_colors[:,:renderer.num_channels]
-            except:
-                import pdb; pdb.set_trace()
+            lighting.vc = mesh_colors[:,:renderer.num_channels]
             lighting.v = mesh_verts
 
             renderer.set(v=mesh_verts, vc=lighting)
@@ -454,11 +451,7 @@ class TestRenderer(unittest.TestCase):
             rbwd = renderer.r
 
             dr_empirical = (np.asarray(rfwd, np.float64) - np.asarray(rbwd, np.float64)).ravel() / eps
-
-            try:
-                dr_predicted = dr.dot(col(direction.flatten())).reshape(dr_empirical.shape)
-            except:
-                import pdb; pdb.set_trace()
+            dr_predicted = dr.dot(col(direction.flatten())).reshape(dr_empirical.shape)
 
             images = OrderedDict()
             images['shifted colors'] = np.asarray(rfwd, np.float64)-.5


### PR DESCRIPTION
Breaking into the debugger is convenient when developing, but is inconvenient in other cases, such as unit tests, since subsequent tests don't run, and the stack trace doesn't print. Same is true of production code, where the process just hangs when it hits the pdb call.