### PR TITLE
wget to write in binary mode

### DIFF
--- a/opendr/utils.py
+++ b/opendr/utils.py
@@ -34,4 +34,4 @@ def wget(url, dest_fname=None):
         contents = urlopen(url).read()
     except:
         raise Exception('Unable to get url: %s' % (url,))
-    open(dest_fname, 'w').write(contents)
+    open(dest_fname, 'wb').write(contents)


### PR DESCRIPTION
This becomes crucial in python 3 since non-binary is UTF-8
Installing package in pip3 fails without this change